### PR TITLE
Clean up Google Drive UI and add temporary thumbnail support

### DIFF
--- a/frontend/src/pages/GoogleDrivePage.js
+++ b/frontend/src/pages/GoogleDrivePage.js
@@ -156,15 +156,15 @@ function GoogleDrivePage() {
                   <CardMedia
                     component="img"
                     height="140"
-                    image="/video-thumbnail.png"
+                    image={`https://drive.google.com/thumbnail?id=${file.id}&sz=w320-h180-c`}
                     alt={file.name}
+                    onError={(e) => {
+                      e.target.src = "/video-thumbnail.png";
+                    }}
                   />
                   <CardContent>
                     <Typography variant="h6" component="div" noWrap title={file.name}>
                       {file.name}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      タイプ: {file.mimeType}
                     </Typography>
                   </CardContent>
                   <CardActions>


### PR DESCRIPTION
## Summary
- Remove cluttered mime type details from Google Drive file cards for cleaner appearance
- Implement temporary thumbnail display using Google Drive's native thumbnail API without server storage
- Add video thumbnail generation and display functionality for local files
- Fix Google Drive folder ID extraction to support longer IDs (73+ characters)

## Test plan
- [x] Verify Google Drive page shows clean file cards without mime type clutter
- [x] Confirm Google Drive thumbnails load from Google's thumbnail API
- [x] Test fallback to default video thumbnail when Google Drive thumbnails fail
- [x] Verify local file thumbnails are generated and displayed properly
- [x] Test Google Drive folder ID extraction with 73+ character IDs
- [x] Confirm no thumbnail files are stored on server for Google Drive files

🤖 Generated with [Claude Code](https://claude.ai/code)