### PR TITLE
Fix Docker Compose circular dependency and RTMP server configuration

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -54,19 +54,24 @@ services:
       start_period: 60s
 
   streamcaster-rtmp:
-    image: tiangolo/nginx-rtmp
+    build: ./rtmp-server
     container_name: streamcaster-rtmp
+    environment:
+      - BACKEND_HOST=streamcaster-backend:3000
+      - CI_MODE=${CI_MODE:-false}
     volumes:
-      - ./rtmp-server/config/nginx.conf:/etc/nginx/nginx.conf
       - streamcaster-data:/opt/rtmp/data
     ports:
       - '1935:1935' # RTMP
       - '8000:8000' # HTTP
+    depends_on:
+      streamcaster-backend:
+        condition: service_healthy
     networks:
       - streamcaster-network
     restart: unless-stopped
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8000/stat']
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:8000/stat']
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,6 @@ services:
       - GOOGLE_API_KEY=${GOOGLE_API_KEY}
     volumes:
       - streamcaster-cache:/app/cache
-    depends_on:
-      streamcaster-rtmp:
-        condition: service_healthy
     networks:
       - streamcaster-network
     restart: unless-stopped
@@ -52,6 +49,9 @@ services:
     ports:
       - '1935:1935' # RTMP
       - '8000:8000' # HTTP
+    depends_on:
+      streamcaster-backend:
+        condition: service_healthy
     networks:
       - streamcaster-network
     restart: unless-stopped


### PR DESCRIPTION
- Remove circular dependency between backend and RTMP services in production docker-compose.yml
- Update development docker-compose.dev.yml to use custom RTMP build instead of tiangolo/nginx-rtmp
- Add proper service dependencies: RTMP now depends on backend being healthy
- Fix health check endpoint to use 127.0.0.1 instead of localhost

This resolves the startup issues where RTMP server couldn't resolve backend hostname and ensures proper service initialization order.

🤖 Generated with [Claude Code](https://claude.ai/code)