### PR TITLE
fix: make husky install optional in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "controller"
   ],
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "husky install || true",
     "controller:start": "cd controller && npm start",
     "controller:test": "cd controller && npm test",
     "controller:lint": "cd controller && npm run lint",


### PR DESCRIPTION
## Summary
- Fixed npm ci error caused by missing husky during CI runs
- Made husky install optional by adding `|| true` to prepare script

## Test plan
- [x] Verified npm ci runs successfully without husky error
- [x] Confirmed husky still installs when available
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)